### PR TITLE
Adding viewHandler to serve index.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 *.dll
 *.so
 *.dylib
-server
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # go_url
 URL shortener in Go
+
+## Structure of the project
+
+```
+go_url/
+├── cmd/ - where we define commands to be run from the command line
+│   └── url_shortener.go - only existing command for now, just starts the url_shortener app
+└── server/ (server package)
+    ├── server.go - defines the server bahavior (start server, routes, etc)
+    └── server_test.go - tests for the server
+```
+
+## Building and running the app
+
+Building and re-running the app is still not automated, so every time you change something, to see the changes on your running app you'll need to stop the server and do
+
+```
+$ go clean github.com/tuttiq/go_url/cmd/url_shortener
+$ go install github.com/tuttiq/go_url/cmd/url_shortener
+$ url_shortener
+```
+
+Assuming you have your `$GOPATH/bin` folder added to your `$PATH`. If not, then replace the last command by `$GOPATH/bin/url_shortener`.
+
+Access the app from `localhost:8080`on your browser.

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -2,15 +2,52 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net/http"
 )
 
-func handler(w http.ResponseWriter, r *http.Request) {
+// Page struct
+type Page struct {
+	Title string
+	Body  []byte
+}
+
+// function to load a page (any page)
+func loadPage(title string) (*Page, error) {
+	filename := title + ".html"
+
+	// read file from view/filename.html
+	body, err := ioutil.ReadFile("views/" + filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// return a Page object with the page title and html body
+	return &Page{Title: title, Body: body}, nil
+}
+
+// function to handle "view" requests
+func viewHandler(w http.ResponseWriter, r *http.Request) {
+	// get the substring after "/view" to use as the page title
+	title := r.URL.Path[len("/view/"):]
+
+	// load page with the title requested
+	p, _ := loadPage(title)
+
+	// parse the HTML body to string to write on the response
+	// TODO: not really using the page title for anything lol
+	fmt.Fprintf(w, string(p.Body))
+}
+
+// dummy Helllo World handler for the root path
+func rootHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
 }
 
 func main() {
-	http.HandleFunc("/", handler)
+	http.HandleFunc("/", rootHandler)
+	http.HandleFunc("/view/", viewHandler)
 	log.Fatal(http.ListenAndServe(":8080", nil))
 }

--- a/cmd/url_shortener/url_shortener.go
+++ b/cmd/url_shortener/url_shortener.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	server "github.com/tuttiq/go_url/server"
+)
+
+func main() {
+	server.StartServer()
+}

--- a/server/server.go
+++ b/server/server.go
@@ -1,8 +1,8 @@
-package main
+package server
 
 import (
 	"fmt"
-	"io/ioutil"
+	// "io/ioutil"
 	"log"
 	"net/http"
 )
@@ -15,14 +15,16 @@ type Page struct {
 
 // function to load a page (any page)
 func loadPage(title string) (*Page, error) {
-	filename := title + ".html"
-
+	// filename := title + ".html"
 	// read file from view/filename.html
-	body, err := ioutil.ReadFile("views/" + filename)
+	// TODO: read from a real file like
+	// body, err := ioutil.ReadFile("views/" + filename)
 
-	if err != nil {
-		return nil, err
-	}
+	body := []byte("<html><body><h1>My Index Page</h1><div>Some body text</div></body></html>")
+
+	// if err != nil {
+	// 	return nil, err
+	// }
 
 	// return a Page object with the page title and html body
 	return &Page{Title: title, Body: body}, nil
@@ -34,7 +36,11 @@ func viewHandler(w http.ResponseWriter, r *http.Request) {
 	title := r.URL.Path[len("/view/"):]
 
 	// load page with the title requested
-	p, _ := loadPage(title)
+	p, err := loadPage(title)
+
+	if err != nil {
+		log.Println(err)
+	}
 
 	// parse the HTML body to string to write on the response
 	// TODO: not really using the page title for anything lol
@@ -46,7 +52,8 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "Hi there, I love %s!", r.URL.Path[1:])
 }
 
-func main() {
+// StartServer starts the server and a minimal router
+func StartServer() {
 	http.HandleFunc("/", rootHandler)
 	http.HandleFunc("/view/", viewHandler)
 	log.Fatal(http.ListenAndServe(":8080", nil))

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1,0 +1,7 @@
+package server
+
+import "testing"
+
+func TestStartServer(t *testing.T) {
+	// How to test a server being served?
+}

--- a/views/index.html
+++ b/views/index.html
@@ -1,0 +1,7 @@
+<html>
+  <body>
+    <h1>My Index Page</h1>
+
+    <div>Some body text</div>
+  </body>
+</html>


### PR DESCRIPTION
Ref https://github.com/tuttiq/go_url/issues/1

- Split the main command line from the server behavior (`cmd` folder and `server` folder)
- Added support for routes starting with `/view/` on the URL
- Added `viewHandler` function to handle requests to `/view/[something]` routes
- Added `Page` struct and `loadPage` function to load a page from an HTML file
- Returns the HTML in the file `views/index.html` when accessing `/view/index` route
- Created folder `views` to store the html files and added `index.html` there
- Updated readme with the following:

## Structure of the project

```
go_url/
├── cmd/ - where we define commands to be run from the command line
│   └── url_shortener.go - only existing command for now, just starts the url_shortener app
├── server/ (server package)
|   ├── server.go - defines the server bahavior (start server, routes, etc)
|   └── server_test.go - tests for the server
└── views / (HTML pages)
    └── index.html
```

## Building and running the app

Building and re-running the app is still not automated, so every time you change something, to see the changes on your running app you'll need to stop the server and do
```
$ go clean github.com/tuttiq/go_url/cmd/url_shortener
$ go install github.com/tuttiq/go_url/cmd/url_shortener
$ url_shortener
```

Assuming you have your `$GOPATH/bin` folder added to your `$PATH`. If not, then replace the last command by `$GOPATH/bin/url_shortener`.

Access the app from `localhost:8080`on your browser.
