### PR TITLE
Adding setup instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # go_url
 URL shortener in Go
+
+## Setup your environment
+
+Install go following [these instructions](https://golang.org/doc/install).
+
+It's [recommended](https://golang.org/doc/code.html#Organization) to organize your go code under a path correspondent to where the package will be published. So create the folder `tuttiq` under `$GOPATH/src/github.com/` if you don't have it yet.
+
+```
+cd $GOPATH/src/github.com/tuttiq
+git clone git@github.com:tuttiq/go_url.git
+```
+
+Build and run the server
+
+```
+go build cmd/server.go
+./server
+```
+
+Access `localhost:8080` on your browser and voilá!


### PR DESCRIPTION
Added the following instructions to the README file (pasting here for easy visualization of the markdown)

## Setup your environment

Install go following [these instructions](https://golang.org/doc/install).

It's [recommended](https://golang.org/doc/code.html#Organization) to organize your go code under a path correspondent to where the package will be published. So create the folder `tuttiq` under `$GOPATH/src/github.com/` if you don't have it yet.

```
cd $GOPATH/src/github.com/tuttiq
git clone git@github.com:tuttiq/go_url.git
```

Build and run the server

```
go build cmd/server.go
./server
```

Access `localhost:8080` on your browser and voilá!